### PR TITLE
Task logging

### DIFF
--- a/labthings/core/tasks/thread.py
+++ b/labthings/core/tasks/thread.py
@@ -243,10 +243,11 @@ class ThreadLogHandler(logging.Handler):
     def emit(self, record):
         """Do something with a logged message"""
         print("emitting a log")
-        self.dest.append({
-            "time": record.created,
-            "level": record.levelname,
-            "message": record.getMessage(),
-        })
+        record_dict = {"message": record.getMessage()}
+        for k in ["created", "levelname", "levelno", "lineno", "filename"]:
+            record_dict[k] = getattr(record, k)
+        self.dest.append(record_dict)
         # FIXME: make sure this doesn't become a memory disaster!
         # We probably need to check the size of the list...
+        # TODO: think about whether any of the keys are security flaws
+        # (this is why I don't dump the whole logrecord)

--- a/labthings/server/schema.py
+++ b/labthings/server/schema.py
@@ -96,6 +96,7 @@ class TaskSchema(Schema):
     _return_value = fields.Raw(data_key="return")
     _start_time = fields.String(data_key="start_time")
     _end_time = fields.String(data_key="end_time")
+    log = fields.List(fields.Dict())
 
     links = fields.Dict()
 


### PR DESCRIPTION
This intercepts log messages saved using ``logging`` that come from task threads, and makes them visible through the web interface.  We might want to think about security implications, though security isn't the primary concern for devices that ought to be operated on fairly private networks...

The logs are viewable through the tasks endpoint.