### PR TITLE
Actions must have post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+# We use poetry, so should ignore the generated setup.py
+/setup.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/labthings/server/spec/td.py
+++ b/labthings/server/spec/td.py
@@ -212,6 +212,12 @@ class ThingDescription:
         self.properties[key] = self.view_to_thing_property(rules, view)
 
     def action(self, rules: list, view: View):
+        """Add a view representing an Action.
+
+        NB at present this will fail for any view that doesn't support POST
+        requests.
+        """
+        assert hasattr(view, "post"), "Thing actions must have a POST method!"
         endpoint = getattr(view, "endpoint") or getattr(rules[0], "endpoint")
         key = snake_to_camel(endpoint)
         self.actions[key] = self.view_to_thing_action(rules, view)


### PR DESCRIPTION
I've added an assert statement to give a more helpful error in the event that we try to create an action from a view that doesn't have a post method.  I tried failing gracefully, but the code as it stands simply won't work if post is missing, and so I've added an assert statement to that effect.