### PR TITLE
Fix task loglevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+# We use poetry, so should ignore the generated setup.py
+/setup.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/labthings/core/tasks/thread.py
+++ b/labthings/core/tasks/thread.py
@@ -130,7 +130,7 @@ class TaskThread(Greenlet):
 
 
 class ThreadLogHandler(logging.Handler):
-    def __init__(self, thread=None, dest=None, level=logging.WARNING):
+    def __init__(self, thread=None, dest=None, level=logging.INFO):
         """Set up a log handler that appends messages to a list.
 
         This log handler will first filter by ``thread``, if one is

--- a/labthings/server/spec/td.py
+++ b/labthings/server/spec/td.py
@@ -212,6 +212,12 @@ class ThingDescription:
         self.properties[key] = self.view_to_thing_property(rules, view)
 
     def action(self, rules: list, view: View):
+        """Add a view representing an Action.
+
+        NB at present this will fail for any view that doesn't support POST
+        requests.
+        """
+        assert hasattr(view, "post"), "Thing actions must have a POST method!"
         endpoint = getattr(view, "endpoint") or getattr(rules[0], "endpoint")
         key = snake_to_camel(endpoint)
         self.actions[key] = self.view_to_thing_action(rules, view)


### PR DESCRIPTION
bump the log level of task thread loggers to INFO by default

Due to me basing it off the wrong branch, this also adds an assert statement about actions requiring a post method.