### PR TITLE
TD op decorators and per-view websockets

### DIFF
--- a/examples/simple_thing.py
+++ b/examples/simple_thing.py
@@ -5,8 +5,8 @@ import time
 import logging
 import atexit
 
-from labthings.server.quick import create_app, semantics, find_component, fields
-from labthings.views import ActionView, PropertyView
+from labthings import create_app, semantics, find_component, fields
+from labthings.views import ActionView, PropertyView, op
 
 
 """
@@ -62,11 +62,13 @@ and register is as a Thing property
 class DenoiseProperty(PropertyView):
     """Value of magic_denoise"""
 
+    @op.readproperty
     def get(self):
         # When a GET request is made, we'll find our attached component
         my_component = find_component("org.labthings.example.mycomponent")
         return my_component.magic_denoise
 
+    @op.writeproperty
     def put(self, new_property_value):
         # Find our attached component
         my_component = find_component("org.labthings.example.mycomponent")
@@ -88,6 +90,7 @@ class QuickDataProperty(PropertyView):
     # Marshal the response as a list of floats
     schema = fields.List(fields.Float())
 
+    @op.readproperty
     def get(self):
         # Find our attached component
         my_component = find_component("org.labthings.example.mycomponent")
@@ -111,6 +114,7 @@ class MeasurementAction(ActionView):
     schema = fields.List(fields.Number)
 
     # Main function to handle POST requests
+    @op.invokeaction
     def post(self, args):
         """Start an averaged measurement"""
 
@@ -134,7 +138,6 @@ atexit.register(cleanup)
 # Create LabThings Flask app
 app, labthing = create_app(
     __name__,
-    prefix="/api",
     title=f"My Lab Device API",
     description="Test LabThing-based API",
     version="0.1.0",

--- a/examples/simple_thing.py
+++ b/examples/simple_thing.py
@@ -44,6 +44,17 @@ class DenoiseProperty(PropertyView):
 
         return my_component.integration_time
 
+    @op.observeproperty
+    def websocket(self, ws):
+        # Find our attached component
+        my_component = find_component("org.labthings.example.mycomponent")
+        initial_value = None
+        while not ws.closed:
+            time.sleep(1)
+            if my_component.integration_time != initial_value:
+                ws.send(encode_json(my_component.integration_time))
+                initial_value = my_component.integration_time
+
 
 """
 Create a view to quickly get some noisy data, and register is as a Thing property
@@ -68,7 +79,6 @@ class QuickDataProperty(PropertyView):
         my_component = find_component("org.labthings.example.mycomponent")
         while not ws.closed:
             ws.send(encode_json(my_component.data))
-            # time.sleep(0.5)
 
 
 """

--- a/poetry.lock
+++ b/poetry.lock
@@ -140,7 +140,7 @@ description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.2"
+version = "5.2.1"
 
 [package.extras]
 toml = ["toml"]
@@ -190,7 +190,7 @@ description = "Barebones websocket extension for Flask, using Pythonthreading fo
 name = "flask-threaded-sockets"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [package.dependencies]
 flask = ">=1.1.2,<2.0.0"
@@ -297,6 +297,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 [[package]]
 category = "dev"
 description = "A fast and thorough lazy object proxy."
+marker = "python_version >= \"3\""
 name = "lazy-object-proxy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -702,7 +703,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.9"
+version = "1.25.10"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -750,6 +751,7 @@ watchdog = ["watchdog"]
 [[package]]
 category = "dev"
 description = "Module for decorators, wrappers and monkey patching."
+marker = "python_version >= \"3\""
 name = "wrapt"
 optional = false
 python-versions = "*"
@@ -780,7 +782,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a7d2bff6345f5f23557cc888802ea19d34b896817341dfbb79ca58eb585ba82c"
+content-hash = "199a43c39b16dddd10fb3f4ea25723b80f9b40d64d76eedec68c3a686a1cd08e"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -833,40 +835,40 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 coverage = [
-    {file = "coverage-5.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:d9ad0a988ae20face62520785ec3595a5e64f35a21762a57d115dae0b8fb894a"},
-    {file = "coverage-5.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:4bb385a747e6ae8a65290b3df60d6c8a692a5599dc66c9fa3520e667886f2e10"},
-    {file = "coverage-5.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:9702e2cb1c6dec01fb8e1a64c015817c0800a6eca287552c47a5ee0ebddccf62"},
-    {file = "coverage-5.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:42fa45a29f1059eda4d3c7b509589cc0343cd6bbf083d6118216830cd1a51613"},
-    {file = "coverage-5.2-cp27-cp27m-win32.whl", hash = "sha256:41d88736c42f4a22c494c32cc48a05828236e37c991bd9760f8923415e3169e4"},
-    {file = "coverage-5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:bbb387811f7a18bdc61a2ea3d102be0c7e239b0db9c83be7bfa50f095db5b92a"},
-    {file = "coverage-5.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:3740b796015b889e46c260ff18b84683fa2e30f0f75a171fb10d2bf9fb91fc70"},
-    {file = "coverage-5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ebf2431b2d457ae5217f3a1179533c456f3272ded16f8ed0b32961a6d90e38ee"},
-    {file = "coverage-5.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:d54d7ea74cc00482a2410d63bf10aa34ebe1c49ac50779652106c867f9986d6b"},
-    {file = "coverage-5.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:87bdc8135b8ee739840eee19b184804e5d57f518578ffc797f5afa2c3c297913"},
-    {file = "coverage-5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ed9a21502e9223f563e071759f769c3d6a2e1ba5328c31e86830368e8d78bc9c"},
-    {file = "coverage-5.2-cp35-cp35m-win32.whl", hash = "sha256:509294f3e76d3f26b35083973fbc952e01e1727656d979b11182f273f08aa80b"},
-    {file = "coverage-5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ca63dae130a2e788f2b249200f01d7fa240f24da0596501d387a50e57aa7075e"},
-    {file = "coverage-5.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:5c74c5b6045969b07c9fb36b665c9cac84d6c174a809fc1b21bdc06c7836d9a0"},
-    {file = "coverage-5.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c32aa13cc3fe86b0f744dfe35a7f879ee33ac0a560684fef0f3e1580352b818f"},
-    {file = "coverage-5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1e58fca3d9ec1a423f1b7f2aa34af4f733cbfa9020c8fe39ca451b6071237405"},
-    {file = "coverage-5.2-cp36-cp36m-win32.whl", hash = "sha256:3b2c34690f613525672697910894b60d15800ac7e779fbd0fccf532486c1ba40"},
-    {file = "coverage-5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a4d511012beb967a39580ba7d2549edf1e6865a33e5fe51e4dce550522b3ac0e"},
-    {file = "coverage-5.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:32ecee61a43be509b91a526819717d5e5650e009a8d5eda8631a59c721d5f3b6"},
-    {file = "coverage-5.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6f91b4492c5cde83bfe462f5b2b997cdf96a138f7c58b1140f05de5751623cf1"},
-    {file = "coverage-5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bfcc811883699ed49afc58b1ed9f80428a18eb9166422bce3c31a53dba00fd1d"},
-    {file = "coverage-5.2-cp37-cp37m-win32.whl", hash = "sha256:60a3d36297b65c7f78329b80120f72947140f45b5c7a017ea730f9112b40f2ec"},
-    {file = "coverage-5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:12eaccd86d9a373aea59869bc9cfa0ab6ba8b1477752110cb4c10d165474f703"},
-    {file = "coverage-5.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:d82db1b9a92cb5c67661ca6616bdca6ff931deceebb98eecbd328812dab52032"},
-    {file = "coverage-5.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:214eb2110217f2636a9329bc766507ab71a3a06a8ea30cdeebb47c24dce5972d"},
-    {file = "coverage-5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8a3decd12e7934d0254939e2bf434bf04a5890c5bf91a982685021786a08087e"},
-    {file = "coverage-5.2-cp38-cp38-win32.whl", hash = "sha256:1dcebae667b73fd4aa69237e6afb39abc2f27520f2358590c1b13dd90e32abe7"},
-    {file = "coverage-5.2-cp38-cp38-win_amd64.whl", hash = "sha256:f50632ef2d749f541ca8e6c07c9928a37f87505ce3a9f20c8446ad310f1aa87b"},
-    {file = "coverage-5.2-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:7403675df5e27745571aba1c957c7da2dacb537c21e14007ec3a417bf31f7f3d"},
-    {file = "coverage-5.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0fc4e0d91350d6f43ef6a61f64a48e917637e1dcfcba4b4b7d543c628ef82c2d"},
-    {file = "coverage-5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:25fe74b5b2f1b4abb11e103bb7984daca8f8292683957d0738cd692f6a7cc64c"},
-    {file = "coverage-5.2-cp39-cp39-win32.whl", hash = "sha256:d67599521dff98ec8c34cd9652cbcfe16ed076a2209625fca9dc7419b6370e5c"},
-    {file = "coverage-5.2-cp39-cp39-win_amd64.whl", hash = "sha256:10f2a618a6e75adf64329f828a6a5b40244c1c50f5ef4ce4109e904e69c71bd2"},
-    {file = "coverage-5.2.tar.gz", hash = "sha256:1874bdc943654ba46d28f179c1846f5710eda3aeb265ff029e0ac2b52daae404"},
+    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:40f70f81be4d34f8d491e55936904db5c527b0711b2a46513641a5729783c2e4"},
+    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:675192fca634f0df69af3493a48224f211f8db4e84452b08d5fcebb9167adb01"},
+    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2fcc8b58953d74d199a1a4d633df8146f0ac36c4e720b4a1997e9b6327af43a8"},
+    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:64c4f340338c68c463f1b56e3f2f0423f7b17ba6c3febae80b81f0e093077f59"},
+    {file = "coverage-5.2.1-cp27-cp27m-win32.whl", hash = "sha256:52f185ffd3291196dc1aae506b42e178a592b0b60a8610b108e6ad892cfc1bb3"},
+    {file = "coverage-5.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:30bc103587e0d3df9e52cd9da1dd915265a22fad0b72afe54daf840c984b564f"},
+    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9ea749fd447ce7fb1ac71f7616371f04054d969d412d37611716721931e36efd"},
+    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651"},
+    {file = "coverage-5.2.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:4869ab1c1ed33953bb2433ce7b894a28d724b7aa76c19b11e2878034a4e4680b"},
+    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a3ee9c793ffefe2944d3a2bd928a0e436cd0ac2d9e3723152d6fd5398838ce7d"},
+    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28f42dc5172ebdc32622a2c3f7ead1b836cdbf253569ae5673f499e35db0bac3"},
+    {file = "coverage-5.2.1-cp35-cp35m-win32.whl", hash = "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"},
+    {file = "coverage-5.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4186fc95c9febeab5681bc3248553d5ec8c2999b8424d4fc3a39c9cba5796962"},
+    {file = "coverage-5.2.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:b360d8fd88d2bad01cb953d81fd2edd4be539df7bfec41e8753fe9f4456a5082"},
+    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1adb6be0dcef0cf9434619d3b892772fdb48e793300f9d762e480e043bd8e716"},
+    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:098a703d913be6fbd146a8c50cc76513d726b022d170e5e98dc56d958fd592fb"},
+    {file = "coverage-5.2.1-cp36-cp36m-win32.whl", hash = "sha256:962c44070c281d86398aeb8f64e1bf37816a4dfc6f4c0f114756b14fc575621d"},
+    {file = "coverage-5.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1ed2bdb27b4c9fc87058a1cb751c4df8752002143ed393899edb82b131e0546"},
+    {file = "coverage-5.2.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:c890728a93fffd0407d7d37c1e6083ff3f9f211c83b4316fae3778417eab9811"},
+    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:538f2fd5eb64366f37c97fdb3077d665fa946d2b6d95447622292f38407f9258"},
+    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:27ca5a2bc04d68f0776f2cdcb8bbd508bbe430a7bf9c02315cd05fb1d86d0034"},
+    {file = "coverage-5.2.1-cp37-cp37m-win32.whl", hash = "sha256:aab75d99f3f2874733946a7648ce87a50019eb90baef931698f96b76b6769a46"},
+    {file = "coverage-5.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c2ff24df02a125b7b346c4c9078c8936da06964cc2d276292c357d64378158f8"},
+    {file = "coverage-5.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:304fbe451698373dc6653772c72c5d5e883a4aadaf20343592a7abb2e643dae0"},
+    {file = "coverage-5.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c96472b8ca5dc135fb0aa62f79b033f02aa434fb03a8b190600a5ae4102df1fd"},
+    {file = "coverage-5.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8505e614c983834239f865da2dd336dcf9d72776b951d5dfa5ac36b987726e1b"},
+    {file = "coverage-5.2.1-cp38-cp38-win32.whl", hash = "sha256:700997b77cfab016533b3e7dbc03b71d33ee4df1d79f2463a318ca0263fc29dd"},
+    {file = "coverage-5.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:46794c815e56f1431c66d81943fa90721bb858375fb36e5903697d5eef88627d"},
+    {file = "coverage-5.2.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:16042dc7f8e632e0dcd5206a5095ebd18cb1d005f4c89694f7f8aafd96dd43a3"},
+    {file = "coverage-5.2.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c1bbb628ed5192124889b51204de27c575b3ffc05a5a91307e7640eff1d48da4"},
+    {file = "coverage-5.2.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4f6428b55d2916a69f8d6453e48a505c07b2245653b0aa9f0dee38785939f5e4"},
+    {file = "coverage-5.2.1-cp39-cp39-win32.whl", hash = "sha256:9e536783a5acee79a9b308be97d3952b662748c4037b6a24cbb339dc7ed8eb89"},
+    {file = "coverage-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b"},
+    {file = "coverage-5.2.1.tar.gz", hash = "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
@@ -881,8 +883,8 @@ flask-cors = [
     {file = "Flask_Cors-3.0.8-py2.py3-none-any.whl", hash = "sha256:f4d97201660e6bbcff2d89d082b5b6d31abee04b1b3003ee073a6fd25ad1d69a"},
 ]
 flask-threaded-sockets = [
-    {file = "flask_threaded_sockets-0.2.0-py3-none-any.whl", hash = "sha256:e3fc55ccf7f22e801b967f15efd4d30ae8627c1fdc3c27e0195ba1bd369e32e1"},
-    {file = "flask_threaded_sockets-0.2.0.tar.gz", hash = "sha256:e9d2ee66ae1c9c2ac86373510c2a4295e0230109130b7bc6d2499f5cd4140361"},
+    {file = "flask_threaded_sockets-0.2.1-py3-none-any.whl", hash = "sha256:80680fb46249bf87eca2a524785d3f019254f6ae7f06df5f3ae6457f17e7ab53"},
+    {file = "flask_threaded_sockets-0.2.1.tar.gz", hash = "sha256:acaed495970568050f04f1cf780e6d845474c1de98e2e1c67bd2c01fa0e6ff55"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -967,11 +969,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 marshmallow = [
@@ -1173,8 +1170,8 @@ unidecode = [
     {file = "Unidecode-1.1.1.tar.gz", hash = "sha256:2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
-    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
+    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -190,7 +190,7 @@ description = "Barebones websocket extension for Flask, using Pythonthreading fo
 name = "flask-threaded-sockets"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.2.1"
+version = "0.3.0"
 
 [package.dependencies]
 flask = ">=1.1.2,<2.0.0"
@@ -782,7 +782,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "199a43c39b16dddd10fb3f4ea25723b80f9b40d64d76eedec68c3a686a1cd08e"
+content-hash = "d783b8bb819680f6430293282df6f1b333a46b4a3b08b4d275250ec48194777d"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -883,8 +883,8 @@ flask-cors = [
     {file = "Flask_Cors-3.0.8-py2.py3-none-any.whl", hash = "sha256:f4d97201660e6bbcff2d89d082b5b6d31abee04b1b3003ee073a6fd25ad1d69a"},
 ]
 flask-threaded-sockets = [
-    {file = "flask_threaded_sockets-0.2.1-py3-none-any.whl", hash = "sha256:80680fb46249bf87eca2a524785d3f019254f6ae7f06df5f3ae6457f17e7ab53"},
-    {file = "flask_threaded_sockets-0.2.1.tar.gz", hash = "sha256:acaed495970568050f04f1cf780e6d845474c1de98e2e1c67bd2c01fa0e6ff55"},
+    {file = "flask_threaded_sockets-0.3.0-py3-none-any.whl", hash = "sha256:d9d070229ad11e3fdf01148b7d1ea69623c9bcf4b5b3be810d424fd479e2b42c"},
+    {file = "flask_threaded_sockets-0.3.0.tar.gz", hash = "sha256:3dee7017abe3e70216740997bd8c1d8ca816b3a0908c0a90fdaac00da2fbdedf"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ webargs = "^6.0.0"
 apispec = "^3.2.0"
 flask-cors = "^3.0.8"
 zeroconf = ">=0.24.5,<0.29.0"
-flask-threaded-sockets = "^0.2.1"
+flask-threaded-sockets = "^0.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ webargs = "^6.0.0"
 apispec = "^3.2.0"
 flask-cors = "^3.0.8"
 zeroconf = ">=0.24.5,<0.29.0"
-flask-threaded-sockets = "^0.2.0"
+flask-threaded-sockets = "^0.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/src/labthings/utilities.py
+++ b/src/labthings/utilities.py
@@ -48,15 +48,21 @@ class ResourceURL(UserString):
     Behaves as a Python string.
     """
 
-    def __init__(self, path: str, external: bool = True):
+    def __init__(self, path: str, external: bool = True, protocol: str = ""):
         self.path = path
         self.external = external
+        # Strip :// if the user mistakenly included it in the argument
+        self.protocol = protocol.rstrip("://")
         UserString.__init__(self, path)
 
     @property
     def data(self):
         if self.external and has_request_context():
             prefix = request.host_url.rstrip("/")
+            # Optional protocol override
+            if self.protocol:
+                # Strip old protocol and replace with custom protocol
+                prefix = self.protocol + "://" + prefix.split("://")[1]
         else:
             prefix = ""
         return prefix + self.path

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -6,6 +6,8 @@ from werkzeug.exceptions import BadRequest
 from .args import use_args
 from .marshalling import marshal_with
 
+from . import op
+
 from ..utilities import unpack, get_docstring, get_summary, merge
 from ..representations import DEFAULT_REPRESENTATIONS
 from ..find import current_labthing
@@ -18,7 +20,7 @@ from .. import fields
 
 import logging
 
-__all__ = ["MethodView", "View", "ActionView", "PropertyView"]
+__all__ = ["MethodView", "View", "ActionView", "PropertyView", "op"]
 
 
 class View(MethodView):
@@ -37,6 +39,7 @@ class View(MethodView):
 
     # Internal
     _cls_tags = set()  # Class tags that shouldn't be removed
+    _opmap = {}  # Mapping of Thing Description ops to class methods
 
     def __init__(self, *args, **kwargs):
         MethodView.__init__(self, *args, **kwargs)
@@ -165,9 +168,16 @@ class ActionView(View):
     default_stop_timeout: int = None  # Time in seconds to wait for the action thread to end after a stop request before terminating it forcefully
 
     # Internal
+    _opmap = {
+        "invokeaction": "post"
+    }  # Mapping of Thing Description ops to class methods
     _cls_tags = {"actions"}
     _deque = Deque()  # Action queue
     _emergency_pool = Pool()
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def get(cls):
@@ -320,6 +330,10 @@ class PropertyView(View):
     responses = {}  # Custom responses for all interactions
 
     # Internal
+    _opmap = {
+        "readproperty": "get",
+        "writeproperty": "put",
+    }  # Mapping of Thing Description ops to class methods
     _cls_tags = {"properties"}
 
     @classmethod

--- a/src/labthings/views/op.py
+++ b/src/labthings/views/op.py
@@ -18,11 +18,15 @@ class readproperty(_opannotation):
     pass
 
 
-class writeproperty(_opannotation):
+class observeproperty(_opannotation):
     pass
 
 
-class observeproperty(_opannotation):
+class unobserveproperty(_opannotation):
+    pass
+
+
+class writeproperty(_opannotation):
     pass
 
 

--- a/src/labthings/views/op.py
+++ b/src/labthings/views/op.py
@@ -1,0 +1,40 @@
+import copy
+
+
+class readproperty:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __set_name__(self, owner, name):
+        if hasattr(owner, "_opmap"):
+            owner._opmap = copy.copy(owner._opmap)
+            owner._opmap.update({"readproperty": name})
+
+        # then replace ourself with the original method
+        setattr(owner, name, self.fn)
+
+
+class writeproperty:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __set_name__(self, owner, name):
+        if hasattr(owner, "_opmap"):
+            owner._opmap = copy.copy(owner._opmap)
+            owner._opmap.update({"writeproperty": name})
+
+        # then replace ourself with the original method
+        setattr(owner, name, self.fn)
+
+
+class observeproperty:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __set_name__(self, owner, name):
+        if hasattr(owner, "_opmap"):
+            owner._opmap = copy.copy(owner._opmap)
+            owner._opmap.update({"observeproperty": name})
+
+        # then replace ourself with the original method
+        setattr(owner, name, self.fn)

--- a/src/labthings/views/op.py
+++ b/src/labthings/views/op.py
@@ -1,40 +1,26 @@
 import copy
 
 
-class readproperty:
+class _opannotation:
     def __init__(self, fn):
         self.fn = fn
 
     def __set_name__(self, owner, name):
         if hasattr(owner, "_opmap"):
             owner._opmap = copy.copy(owner._opmap)
-            owner._opmap.update({"readproperty": name})
+            owner._opmap.update({self.__class__.__name__: name})
 
         # then replace ourself with the original method
         setattr(owner, name, self.fn)
 
 
-class writeproperty:
-    def __init__(self, fn):
-        self.fn = fn
-
-    def __set_name__(self, owner, name):
-        if hasattr(owner, "_opmap"):
-            owner._opmap = copy.copy(owner._opmap)
-            owner._opmap.update({"writeproperty": name})
-
-        # then replace ourself with the original method
-        setattr(owner, name, self.fn)
+class readproperty(_opannotation):
+    pass
 
 
-class observeproperty:
-    def __init__(self, fn):
-        self.fn = fn
+class writeproperty(_opannotation):
+    pass
 
-    def __set_name__(self, owner, name):
-        if hasattr(owner, "_opmap"):
-            owner._opmap = copy.copy(owner._opmap)
-            owner._opmap.update({"observeproperty": name})
 
-        # then replace ourself with the original method
-        setattr(owner, name, self.fn)
+class observeproperty(_opannotation):
+    pass

--- a/src/labthings/views/op.py
+++ b/src/labthings/views/op.py
@@ -24,3 +24,7 @@ class writeproperty(_opannotation):
 
 class observeproperty(_opannotation):
     pass
+
+
+class invokeaction(_opannotation):
+    pass

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from labthings.views import View
+from labthings.views import View, op
 from labthings import semantics
 
 
@@ -12,6 +12,7 @@ def thing_description(thing):
 def test_moz_BooleanProperty(helpers, app, thing_description, app_ctx, schemas_path):
     @semantics.moz.BooleanProperty()
     class Index(View):
+        @op.readproperty
         def get(self):
             return "GET"
 
@@ -32,6 +33,7 @@ def test_moz_BooleanProperty(helpers, app, thing_description, app_ctx, schemas_p
 def test_moz_LevelProperty(helpers, app, thing_description, app_ctx, schemas_path):
     @semantics.moz.LevelProperty(0, 100)
     class Index(View):
+        @op.readproperty
         def get(self):
             return "GET"
 
@@ -55,6 +57,7 @@ def test_moz_LevelProperty(helpers, app, thing_description, app_ctx, schemas_pat
 def test_moz_BrightnessProperty(helpers, app, thing_description, app_ctx, schemas_path):
     @semantics.moz.BrightnessProperty()
     class Index(View):
+        @op.readproperty
         def get(self):
             return "GET"
 
@@ -78,6 +81,7 @@ def test_moz_BrightnessProperty(helpers, app, thing_description, app_ctx, schema
 def test_moz_OnOffProperty(helpers, app, thing_description, app_ctx, schemas_path):
     @semantics.moz.OnOffProperty()
     class Index(View):
+        @op.readproperty
         def get(self):
             return "GET"
 

--- a/tests/test_td.py
+++ b/tests/test_td.py
@@ -50,33 +50,39 @@ def test_td_links(thing_description, app_ctx, view_cls):
         )
 
 
-def test_td_action(helpers, app, thing_description, view_cls, app_ctx, schemas_path):
-    app.add_url_rule("/", view_func=view_cls.as_view("index"))
+def test_td_action(helpers, app, thing_description, app_ctx, schemas_path):
+    class Index(ActionView):
+        def post(self):
+            return "POST"
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
     rules = app.url_map._rules_by_endpoint["index"]
 
-    thing_description.action(rules, view_cls)
+    thing_description.action(rules, Index)
 
     with app_ctx.test_request_context():
         assert "index" in thing_description.to_dict().get("actions")
         helpers.validate_thing_description(thing_description, app_ctx, schemas_path)
 
 
-def test_td_action_with_schema(
-    helpers, app, thing_description, view_cls, app_ctx, schemas_path
-):
-    view_cls.args = {"integer": fields.Int()}
-    view_cls.semtype = "ToggleAction"
+def test_td_action_with_schema(helpers, app, thing_description, app_ctx, schemas_path):
+    class Index(ActionView):
+        args = {"integer": fields.Int()}
+        semtype = "ToggleAction"
 
-    app.add_url_rule("/", view_func=view_cls.as_view("index"))
+        def post(self):
+            return "POST"
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
     rules = app.url_map._rules_by_endpoint["index"]
 
-    thing_description.action(rules, view_cls)
+    thing_description.action(rules, Index)
 
     with app_ctx.test_request_context():
         assert "index" in thing_description.to_dict().get("actions")
 
         assert thing_description.to_dict().get("actions").get("index") == {
-            "title": "ViewClass",
+            "title": "Index",
             "description": "",
             "links": [{"href": "/"}],
             "safe": False,

--- a/tests/test_td.py
+++ b/tests/test_td.py
@@ -2,7 +2,7 @@ import pytest
 
 from labthings import fields
 
-from labthings.views import View, PropertyView, ActionView
+from labthings.views import View, PropertyView, ActionView, op
 
 
 @pytest.fixture
@@ -170,6 +170,7 @@ def test_td_property_post_to_write(
     helpers, app, thing_description, app_ctx, schemas_path
 ):
     class Index(PropertyView):
+        @op.writeproperty
         def post(self):
             return "POST"
 
@@ -197,11 +198,8 @@ def test_td_property_post_to_write(
 def test_td_property_different_content_type(
     helpers, app, thing_description, app_ctx, schemas_path
 ):
-    class Index(ActionView):
+    class Index(PropertyView):
         content_type = "text/plain; charset=us-ascii"
-
-        def get(self):
-            return "GET"
 
         def put(self):
             return "PUT"
@@ -226,7 +224,7 @@ def test_td_action_different_response_type(
         response_content_type = "text/plain; charset=us-ascii"
 
         def post(self):
-            return "PUT"
+            return "POST"
 
     app.add_url_rule("/", view_func=Index.as_view("index"))
     rules = app.url_map._rules_by_endpoint["index"]

--- a/tests/test_views_op.py
+++ b/tests/test_views_op.py
@@ -1,0 +1,62 @@
+import pytest
+
+from labthings.views import View, op
+
+
+@pytest.fixture
+def thing_description(thing):
+    return thing.thing_description
+
+
+def test_op_readproperty(helpers, app, thing_description, app_ctx, schemas_path):
+    class Index(View):
+        @op.readproperty
+        def get(self):
+            return "GET"
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
+    rules = app.url_map._rules_by_endpoint["index"]
+
+    thing_description.property(rules, Index)
+
+    with app_ctx.test_request_context():
+        assert "index" in thing_description.to_dict()["properties"]
+        assert (
+            thing_description.to_dict()["properties"]["index"]["forms"][0]["op"]
+            == "readproperty"
+        )
+
+        assert (
+            thing_description.to_dict()["properties"]["index"]["forms"][0][
+                "htv:methodName"
+            ]
+            == "GET"
+        )
+        helpers.validate_thing_description(thing_description, app_ctx, schemas_path)
+
+
+def test_op_writeproperty(helpers, app, thing_description, app_ctx, schemas_path):
+    class Index(View):
+        @op.writeproperty
+        def put(self):
+            return "PUT"
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
+    rules = app.url_map._rules_by_endpoint["index"]
+
+    thing_description.property(rules, Index)
+
+    with app_ctx.test_request_context():
+        assert "index" in thing_description.to_dict()["properties"]
+        assert (
+            thing_description.to_dict()["properties"]["index"]["forms"][0]["op"]
+            == "writeproperty"
+        )
+
+        assert (
+            thing_description.to_dict()["properties"]["index"]["forms"][0][
+                "htv:methodName"
+            ]
+            == "PUT"
+        )
+        helpers.validate_thing_description(thing_description, app_ctx, schemas_path)


### PR DESCRIPTION
Adds support for overriding which Thing Description ops map to which View methods.

Also enables a View to have a `websocket` method that attaches a websocket protocol to the View.