### PR TITLE
Handle action exceptions

### DIFF
--- a/src/labthings/actions/pool.py
+++ b/src/labthings/actions/pool.py
@@ -29,7 +29,7 @@ class Pool:
         self.add(thread)
         thread.start()
 
-    def spawn(self, action: str, function, *args, **kwargs):
+    def spawn(self, action: str, function, http_error_lock=None, *args, **kwargs):
         """
 
         :param function:
@@ -37,7 +37,13 @@ class Pool:
         :param **kwargs:
 
         """
-        thread = ActionThread(action, target=function, args=args, kwargs=kwargs)
+        thread = ActionThread(
+            action, 
+            target=function, 
+            http_error_lock=http_error_lock, 
+            args=args, 
+            kwargs=kwargs
+        )
         self.start(thread)
         return thread
 

--- a/src/labthings/actions/pool.py
+++ b/src/labthings/actions/pool.py
@@ -29,7 +29,7 @@ class Pool:
         self.add(thread)
         thread.start()
 
-    def spawn(self, action: str, function, http_error_lock=None, *args, **kwargs):
+    def spawn(self, action: str, function, *args, http_error_lock=None, **kwargs):
         """
 
         :param function:
@@ -38,11 +38,11 @@ class Pool:
 
         """
         thread = ActionThread(
-            action, 
-            target=function, 
-            http_error_lock=http_error_lock, 
-            args=args, 
-            kwargs=kwargs
+            action,
+            target=function,
+            http_error_lock=http_error_lock,
+            args=args,
+            kwargs=kwargs,
         )
         self.start(thread)
         return thread

--- a/src/labthings/actions/thread.py
+++ b/src/labthings/actions/thread.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Any, Callable, Dict, Iterable, Optional
 
 from flask import copy_current_request_context, has_request_context, request
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, HTTPException
 
 from ..deque import LockableDeque
 from ..utilities import TimeoutTracker
@@ -22,6 +22,42 @@ class ActionKilledException(SystemExit):
 class ActionThread(threading.Thread):
     """
     A native thread with extra functionality for tracking progress and thread termination.
+
+    Arguments:
+    * `action` is the name of the action that's running
+    * `target`, `name`, `args`, `kwargs` and `daemon` are passed to `threading.Thread`
+      (though the defualt for `daemon` is changed to `True`)
+    * `default_stop_timeout` specifies how long we wait for the `target` function to
+      stop nicely (e.g. by checking the `stopping` Event )
+    * `log_len` gives the number of log entries before we start dumping them
+    * `http_error_lock` allows the calling thread to handle some
+      errors initially.  See below.
+
+    ## Error propagation
+    If the `target` function throws an Exception, by default this will result in:
+    * The thread terminating
+    * The Action's status being set to `error`
+    * The exception appearing in the logs with a traceback
+    * The exception being raised in the background thread.
+    However, `HTTPException` subclasses are used in Flask/Werkzeug web apps to
+    return HTTP status codes indicating specific errors, and so merit being 
+    handled differently.
+
+    Normally, when an Action is initiated, the thread handling the HTTP request
+    does not return immediately - it waits for a short period to check whether
+    the Action has completed or returned an error.  If an HTTPError is raised
+    in the Action thread before the initiating thread has sent an HTTP response,
+    we **don't** want to propagate the error here, but instead want to re-raise
+    it in the calling thread.  This will then mean that the HTTP request is
+    answered with the appropriate error code, rather than returning a `201` 
+    code, along with a description of the task (showing that it was successfully
+    started, but also showing that it subsequently failed with an error).
+
+    In order to activate this behaviour, we must pass in a `threading.Lock` 
+    object.  This lock should already be acquired by the request-handling
+    thread.  If an error occurs, and this lock is acquired, the exception
+    should not be re-raised until the calling thread has had the chance to deal 
+    with it.
     """
 
     def __init__(
@@ -34,6 +70,7 @@ class ActionThread(threading.Thread):
         daemon: bool = True,
         default_stop_timeout: int = 5,
         log_len: int = 100,
+        http_error_lock: Optional[threading.Lock] = None
     ):
         threading.Thread.__init__(
             self,
@@ -56,6 +93,8 @@ class ActionThread(threading.Thread):
         # Event to track if the user has requested stop
         self.stopping: threading.Event = threading.Event()
         self.default_stop_timeout: int = default_stop_timeout
+        # Allow the calling thread to handle HTTP errors for a short time at the start
+        self.http_error_lock = http_error_lock or threading.Lock()
 
         # Make _target, _args, and _kwargs available to the subclass
         self._target: Optional[Callable] = target
@@ -220,16 +259,32 @@ class ActionThread(threading.Thread):
                 # Set state to stopped
                 self._status = "cancelled"
                 self.progress = None
-            except Exception as e:  # skipcq: PYL-W0703
-                logging.error(traceback.format_exc())
-                self._return_value = str(e)
-                self._status = "error"
+            except HTTPException as e:
                 self._exception = e
+                # If the lock is acquired elsewhere, assume the error
+                # will be handled there.
+                if self.http_error_lock.acquire(blocking=False):
+                    self.http_error_lock.release()
+                    logging.error(
+                        "An HTTPException occurred in an action thread, but "
+                        "the parent request was no longer waiting for it."
+                    )
+                    logging.error(traceback.format_exc())
+                    raise e
+                else:
+                    logging.info(f"Propagating {e} back to request handler")
+            except Exception as e:  # skipcq: PYL-W0703
+                self._exception = e
+                logging.error(traceback.format_exc())
                 raise e
             finally:
                 self._end_time = datetime.datetime.now()
                 logging.getLogger().removeHandler(handler)  # Stop logging this thread
                 # If we don't remove the handler, it's a memory leak.
+                if self._exception:
+                    self._return_value = str(self._exception)
+                    self._status = "error"
+
 
         return wrapped
 

--- a/src/labthings/actions/thread.py
+++ b/src/labthings/actions/thread.py
@@ -152,6 +152,11 @@ class ActionThread(threading.Thread):
         """Alias of `stopped`"""
         return self.stopped
 
+    @property
+    def exception(self) -> Optional[Exception]:
+        """The Exception that caused the action to fail."""
+        return self._exception
+
     def update_progress(self, progress: int):
         """
         Update the progress of the ActionThread.

--- a/src/labthings/actions/thread.py
+++ b/src/labthings/actions/thread.py
@@ -85,6 +85,7 @@ class ActionThread(threading.Thread):
         self._request_time: datetime.datetime = datetime.datetime.now()
         self._start_time: Optional[datetime.datetime] = None  # Task start time
         self._end_time: Optional[datetime.datetime] = None  # Task end time
+        self._exception: Optional[Exception] = None  # Propagate exceptions helpfully
 
         # Public state properties
         self.progress: Optional[int] = None  # Percent progress of the task
@@ -218,6 +219,7 @@ class ActionThread(threading.Thread):
                 logging.error(traceback.format_exc())
                 self._return_value = str(e)
                 self._status = "error"
+                self._exception = e
                 raise e
             finally:
                 self._end_time = datetime.datetime.now()

--- a/src/labthings/actions/thread.py
+++ b/src/labthings/actions/thread.py
@@ -40,7 +40,7 @@ class ActionThread(threading.Thread):
     * The exception appearing in the logs with a traceback
     * The exception being raised in the background thread.
     However, `HTTPException` subclasses are used in Flask/Werkzeug web apps to
-    return HTTP status codes indicating specific errors, and so merit being 
+    return HTTP status codes indicating specific errors, and so merit being
     handled differently.
 
     Normally, when an Action is initiated, the thread handling the HTTP request
@@ -49,14 +49,14 @@ class ActionThread(threading.Thread):
     in the Action thread before the initiating thread has sent an HTTP response,
     we **don't** want to propagate the error here, but instead want to re-raise
     it in the calling thread.  This will then mean that the HTTP request is
-    answered with the appropriate error code, rather than returning a `201` 
+    answered with the appropriate error code, rather than returning a `201`
     code, along with a description of the task (showing that it was successfully
     started, but also showing that it subsequently failed with an error).
 
-    In order to activate this behaviour, we must pass in a `threading.Lock` 
+    In order to activate this behaviour, we must pass in a `threading.Lock`
     object.  This lock should already be acquired by the request-handling
     thread.  If an error occurs, and this lock is acquired, the exception
-    should not be re-raised until the calling thread has had the chance to deal 
+    should not be re-raised until the calling thread has had the chance to deal
     with it.
     """
 
@@ -70,7 +70,7 @@ class ActionThread(threading.Thread):
         daemon: bool = True,
         default_stop_timeout: int = 5,
         log_len: int = 100,
-        http_error_lock: Optional[threading.Lock] = None
+        http_error_lock: Optional[threading.Lock] = None,
     ):
         threading.Thread.__init__(
             self,
@@ -271,8 +271,6 @@ class ActionThread(threading.Thread):
                     )
                     logging.error(traceback.format_exc())
                     raise e
-                else:
-                    logging.info(f"Propagating {e} back to request handler")
             except Exception as e:  # skipcq: PYL-W0703
                 self._exception = e
                 logging.error(traceback.format_exc())
@@ -284,7 +282,6 @@ class ActionThread(threading.Thread):
                 if self._exception:
                     self._return_value = str(self._exception)
                     self._status = "error"
-
 
         return wrapped
 

--- a/src/labthings/schema.py
+++ b/src/labthings/schema.py
@@ -82,7 +82,11 @@ class LogRecordSchema(Schema):
 
 
 class ActionSchema(Schema):
-    """ """
+    """Represents a running or completed Action
+    
+    Actions can run in the background, started by one request
+    and subsequently polled for updates.  This schema represents
+    one Action."""
 
     action = fields.String()
     _ID = fields.String(data_key="id")

--- a/src/labthings/schema.py
+++ b/src/labthings/schema.py
@@ -83,7 +83,7 @@ class LogRecordSchema(Schema):
 
 class ActionSchema(Schema):
     """Represents a running or completed Action
-    
+
     Actions can run in the background, started by one request
     and subsequently polled for updates.  This schema represents
     one Action."""

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -234,6 +234,13 @@ class ActionView(View):
         if task.output and isinstance(task.output, ResponseBase):
             return self.represent_response((task.output, 200))
 
+        # If the action fails quickly, propagate the exception.
+        # This allows us to handle validation errors nicely.
+        # TODO: do we want to do this for all exceptions, or just
+        # werkzeug.exceptions.HTTPException instances?
+        if task._exception is not None:
+            raise e
+
         return self.represent_response((ActionSchema().dump(task), 201))
 
 

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -5,8 +5,8 @@ from typing import Callable, Dict, List, Optional, Set, cast
 from flask import request
 from flask.views import MethodView
 from typing_extensions import Protocol
-from werkzeug.wrappers import Response as ResponseBase
 from werkzeug.exceptions import HTTPException
+from werkzeug.wrappers import Response as ResponseBase
 
 from ..actions.pool import Pool
 from ..deque import Deque

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -239,7 +239,7 @@ class ActionView(View):
         # TODO: do we want to do this for all exceptions, or just
         # werkzeug.exceptions.HTTPException instances?
         if task._exception is not None:
-            raise e
+            raise task._exception
 
         return self.represent_response((ActionSchema().dump(task), 201))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 import jsonschema
 import pytest
@@ -213,7 +214,7 @@ def thing_with_some_views(thing):
     thing.add_view(TestFieldProperty, "/TestFieldProperty")
 
     class FailAction(ActionView):
-        wait_for = 1.0
+        wait_for = 0.1
 
         def post(self):
             raise Exception("This action is meant to fail with an Exception")
@@ -221,18 +222,21 @@ def thing_with_some_views(thing):
     thing.add_view(FailAction, "/FailAction")
 
     class AbortAction(ActionView):
-        wait_for = 1.0
+        wait_for = 0.1
+        args = {"abort_after": fields.Number()}
 
-        def post(self):
+        def post(self, args):
+            if args.get("abort_after", 0) > 0:
+                time.sleep(args["abort_after"])
             abort(418, "I'm a teapot! This action should abort with an HTTP code 418")
 
     thing.add_view(AbortAction, "/AbortAction")
 
     class ActionWithValidation(ActionView):
-        wait_for = 1.0
+        wait_for = 0.1
         args = {"test_arg": fields.String(validate=validate.OneOf(["one", "two"]))}
 
-        def post(self):
+        def post(self, args):
             return True
 
     thing.add_view(ActionWithValidation, "/ActionWithValidation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,26 +211,30 @@ def thing_with_some_views(thing):
             pass
 
     thing.add_view(TestFieldProperty, "/TestFieldProperty")
-    
+
     class FailAction(ActionView):
         wait_for = 1.0
+
         def post(self):
             raise Exception("This action is meant to fail with an Exception")
-    
+
     thing.add_view(FailAction, "/FailAction")
 
     class AbortAction(ActionView):
         wait_for = 1.0
+
         def post(self):
             abort(418, "I'm a teapot! This action should abort with an HTTP code 418")
-    
+
     thing.add_view(AbortAction, "/AbortAction")
 
     class ActionWithValidation(ActionView):
         wait_for = 1.0
         args = {"test_arg": fields.String(validate=validate.OneOf(["one", "two"]))}
+
         def post(self):
             return True
+
     thing.add_view(ActionWithValidation, "/ActionWithValidation")
 
     return thing

--- a/tests/test_action_api.py
+++ b/tests/test_action_api.py
@@ -43,13 +43,14 @@ def test_action_abort(thing_with_some_views, client):
     r = client.post("/AbortAction")
     assert r.status_code == 418
 
+
 @pytest.mark.filterwarnings("ignore:Exception in thread")
 def test_action_abort_late(thing_with_some_views, client, caplog):
     """Check HTTPExceptions raised late are just regular errors."""
     caplog.set_level(logging.ERROR)
     caplog.clear()
     r = client.post("/AbortAction", data=json.dumps({"abort_after": 0.2}))
-    assert r.status_code == 201 # Should have started OK
+    assert r.status_code == 201  # Should have started OK
     time.sleep(0.3)
     # Now check the status - should be error
     r2 = client.get(r.get_json()["links"]["self"]["href"])
@@ -57,13 +58,9 @@ def test_action_abort_late(thing_with_some_views, client, caplog):
     # Check it was logged as well
     error_was_raised = False
     for r in caplog.records:
-        if (
-            r.levelname == "ERROR"
-            and "HTTPException" in r.message
-        ):
+        if r.levelname == "ERROR" and "HTTPException" in r.message:
             error_was_raised = True
     assert error_was_raised
-        
 
 
 def test_action_validate(thing_with_some_views, client):

--- a/tests/test_action_api.py
+++ b/tests/test_action_api.py
@@ -1,0 +1,50 @@
+import pytest
+import time
+import json
+
+from labthings import LabThing
+from labthings.views import ActionView
+
+@pytest.mark.filterwarnings("ignore:Exception in thread")
+def test_action_exception_handling(thing_with_some_views, client):
+    """Check errors in an Action are handled correctly
+
+    
+
+    `/FieldProperty` has a validation constraint - it
+    should return a "bad response" error if invoked with
+    anything other than 
+    """
+    # `/FailAction` raises an `Exception`.    
+    # This ought to return a 201 code representing the 
+    # action that was successfully started - but should 
+    # show that it failed through the "status" field.
+
+    # This is correct for the current (24/7/2021) behaviour
+    # but may want to change for the next version, e.g. 
+    # returning a 500 code.  For further discussion...
+    r = client.post("/FailAction")
+    assert r.status_code == 201
+    action = r.get_json()
+    assert action["status"] == "error"
+
+def test_action_abort_and_validation(thing_with_some_views, client):
+    """Check HTTPExceptions result in error codes.
+    
+    Subclasses of HTTPError should result in a non-200 return code, not
+    just failures.  This covers Marshmallow validation (400) and
+    use of `abort()`.
+    """
+    # `/AbortAction` should return a 418 error code
+    r = client.post("/AbortAction")
+    assert r.status_code == 418
+    
+def test_action_validate(thing_with_some_views, client):
+    # `/ActionWithValidation` should fail with a 400 error
+    # if `test_arg` is not either `one` or `two`
+    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg":"one"}))
+    assert r.status_code in [200, 201]
+    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg":"three"}))
+    assert r.status_code in [422]
+    
+

--- a/tests/test_action_api.py
+++ b/tests/test_action_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 
 import pytest
@@ -31,7 +32,7 @@ def test_action_exception_handling(thing_with_some_views, client):
     assert action["status"] == "error"
 
 
-def test_action_abort_and_validation(thing_with_some_views, client):
+def test_action_abort(thing_with_some_views, client):
     """Check HTTPExceptions result in error codes.
 
     Subclasses of HTTPError should result in a non-200 return code, not
@@ -42,11 +43,35 @@ def test_action_abort_and_validation(thing_with_some_views, client):
     r = client.post("/AbortAction")
     assert r.status_code == 418
 
+@pytest.mark.filterwarnings("ignore:Exception in thread")
+def test_action_abort_late(thing_with_some_views, client, caplog):
+    """Check HTTPExceptions raised late are just regular errors."""
+    caplog.set_level(logging.ERROR)
+    caplog.clear()
+    r = client.post("/AbortAction", data=json.dumps({"abort_after": 0.2}))
+    assert r.status_code == 201 # Should have started OK
+    time.sleep(0.3)
+    # Now check the status - should be error
+    r2 = client.get(r.get_json()["links"]["self"]["href"])
+    assert r2.get_json()["status"] == "error"
+    # Check it was logged as well
+    error_was_raised = False
+    for r in caplog.records:
+        if (
+            r.levelname == "ERROR"
+            and "HTTPException" in r.message
+        ):
+            error_was_raised = True
+    assert error_was_raised
+        
+
 
 def test_action_validate(thing_with_some_views, client):
+    """Validation errors should result in 422 return codes."""
     # `/ActionWithValidation` should fail with a 400 error
     # if `test_arg` is not either `one` or `two`
     r = client.post("/ActionWithValidation", data=json.dumps({"test_arg": "one"}))
     assert r.status_code in [200, 201]
+    assert r.get_json()["status"] == "completed"
     r = client.post("/ActionWithValidation", data=json.dumps({"test_arg": "three"}))
     assert r.status_code in [422]

--- a/tests/test_action_api.py
+++ b/tests/test_action_api.py
@@ -1,36 +1,39 @@
-import pytest
-import time
 import json
+import time
+
+import pytest
 
 from labthings import LabThing
 from labthings.views import ActionView
+
 
 @pytest.mark.filterwarnings("ignore:Exception in thread")
 def test_action_exception_handling(thing_with_some_views, client):
     """Check errors in an Action are handled correctly
 
-    
+
 
     `/FieldProperty` has a validation constraint - it
     should return a "bad response" error if invoked with
-    anything other than 
+    anything other than
     """
-    # `/FailAction` raises an `Exception`.    
-    # This ought to return a 201 code representing the 
-    # action that was successfully started - but should 
+    # `/FailAction` raises an `Exception`.
+    # This ought to return a 201 code representing the
+    # action that was successfully started - but should
     # show that it failed through the "status" field.
 
     # This is correct for the current (24/7/2021) behaviour
-    # but may want to change for the next version, e.g. 
+    # but may want to change for the next version, e.g.
     # returning a 500 code.  For further discussion...
     r = client.post("/FailAction")
     assert r.status_code == 201
     action = r.get_json()
     assert action["status"] == "error"
 
+
 def test_action_abort_and_validation(thing_with_some_views, client):
     """Check HTTPExceptions result in error codes.
-    
+
     Subclasses of HTTPError should result in a non-200 return code, not
     just failures.  This covers Marshmallow validation (400) and
     use of `abort()`.
@@ -38,13 +41,12 @@ def test_action_abort_and_validation(thing_with_some_views, client):
     # `/AbortAction` should return a 418 error code
     r = client.post("/AbortAction")
     assert r.status_code == 418
-    
+
+
 def test_action_validate(thing_with_some_views, client):
     # `/ActionWithValidation` should fail with a 400 error
     # if `test_arg` is not either `one` or `two`
-    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg":"one"}))
+    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg": "one"}))
     assert r.status_code in [200, 201]
-    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg":"three"}))
+    r = client.post("/ActionWithValidation", data=json.dumps({"test_arg": "three"}))
     assert r.status_code in [422]
-    
-

--- a/tests/test_labthing_exceptions.py
+++ b/tests/test_labthing_exceptions.py
@@ -65,7 +65,7 @@ def test_blank_exception(app):
     e = Exception()
     e.message = None
 
-    # Test a 404 HTTPException
+    # Test an empty Exception
     response = error_handler.std_handler(e)
 
     response_json = json.dumps(response[0])

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -108,16 +108,13 @@ def dict_is_openapi(d):
     return True
 
 
-def test_openapi_json_endpoint(thing):
-    c = thing.app.test_client()
-    r = c.get("/docs/openapi")
+def test_openapi_json_endpoint(thing, client):
+    r = client.get("/docs/openapi")
     assert r.status_code == 200
     assert dict_is_openapi(r.get_json())
 
 
-def test_openapi_yaml_endpoint(thing):
-    c = thing.app.test_client()
-
-    r = c.get("/docs/openapi.yaml")
+def test_openapi_yaml_endpoint(thing, client):
+    r = client.get("/docs/openapi.yaml")
     assert r.status_code == 200
     assert dict_is_openapi(yaml.safe_load(r.data))

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -16,8 +16,8 @@ from labthings.actions.thread import ActionThread
 from labthings.apispec import utilities
 from labthings.extensions import BaseExtension
 from labthings.schema import LogRecordSchema, Schema
-from labthings.views import ActionView, EventView, PropertyView
 from labthings.utilities import get_by_path
+from labthings.views import ActionView, EventView, PropertyView
 
 
 def test_openapi(thing_with_some_views):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -41,9 +41,12 @@ def test_duplicate_action_name(thing_with_some_views):
     with pytest.warns(UserWarning):
         t.add_view(TestAction, "TestActionM", endpoint="TestActionM")
 
+    # We should have two actions with the same name
+    actions_named_testaction = 0
     for v in t._action_views.values():
-        # We should have two actions with the same name
-        assert v.__name__ == "TestAction"
+        if v.__name__ == "TestAction":
+            actions_named_testaction += 1
+    assert actions_named_testaction >= 2
 
     api = t.spec.to_dict()
     original_input_schema = get_by_path(api, ["paths", "/TestAction", "post"])

--- a/tests/test_tasks_thread.py
+++ b/tests/test_tasks_thread.py
@@ -115,6 +115,7 @@ def test_task_get_noblock_timeout():
         assert task_obj.get(block=False, timeout=0)
 
 
+@pytest.mark.filterwarnings("ignore:Exception in thread")
 def test_task_exception():
     exc_to_raise = Exception("Exception message")
 


### PR DESCRIPTION
If an action raises an exception before the corresponding view has returned a response to a POST request (i.e. within the first 1-2s), instead of returning a 201 "created" response and a task object, raise the exception instead.

This means that marshmallow validation errors can now give helpful responses.

This also means that a non-marshmallow exception will make a mess of the task mechanism if it happens early - so we may not want to accept the MR as-is...

Closes #184 