### PR TITLE
Improve openapi

### DIFF
--- a/src/labthings/apispec/plugins.py
+++ b/src/labthings/apispec/plugins.py
@@ -60,14 +60,14 @@ class FlaskLabThingsPlugin(BasePlugin):
 
         for method in http_method_funcs:
             if hasattr(interaction, method):
-                property = getattr(interaction, method)
+                prop = getattr(interaction, method)
                 d[method] = {
-                    "description": getattr(property, "description", None)
-                    or get_docstring(property, remove_newlines=False)
+                    "description": getattr(prop, "description", None)
+                    or get_docstring(prop, remove_newlines=False)
                     or getattr(interaction, "description", None)
                     or get_docstring(interaction, remove_newlines=False),
-                    "summary": getattr(property, "summary", None)
-                    or get_summary(property)
+                    "summary": getattr(prop, "summary", None)
+                    or get_summary(prop)
                     or getattr(interaction, "summary", None)
                     or get_summary(interaction),
                     "tags": list(interaction.get_tags()),

--- a/src/labthings/apispec/plugins.py
+++ b/src/labthings/apispec/plugins.py
@@ -60,14 +60,19 @@ class FlaskLabThingsPlugin(BasePlugin):
 
         for method in http_method_funcs:
             if hasattr(interaction, method):
+                property = getattr(interaction, method)
                 d[method] = {
-                    "description": getattr(interaction, "description", None)
-                    or get_docstring(interaction),
-                    "summary": getattr(interaction, "summary", None)
+                    "description": getattr(property, "description", None)
+                    or get_docstring(property, remove_newlines=False)
+                    or getattr(interaction, "description", None)
+                    or get_docstring(interaction, remove_newlines=False),
+                    "summary": getattr(property, "summary", None)
+                    or get_summary(property)
+                    or getattr(interaction, "summary", None)
                     or get_summary(interaction),
                     "tags": list(interaction.get_tags()),
                     "responses": {
-                        "default": {
+                        "5XX": {
                             "description": "Unexpected error",
                             "content": {
                                 "application/json": {

--- a/src/labthings/utilities.py
+++ b/src/labthings/utilities.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import operator
 import os
 import re
@@ -152,12 +153,12 @@ def get_docstring(obj: Any, remove_newlines=True) -> str:
 
     """
     ds = obj.__doc__
-    if ds:
+    if not ds:
+        return ""
+    if remove_newlines:
         stripped = [line.strip() for line in ds.splitlines() if line]
-        if not remove_newlines:
-            return "\n".join(stripped)
         return " ".join(stripped).replace("\n", " ").replace("\r", "")
-    return ""
+    return inspect.cleandoc(ds) # Strip spurious indentation/newlines
 
 
 def get_summary(obj: Any) -> str:

--- a/src/labthings/utilities.py
+++ b/src/labthings/utilities.py
@@ -158,7 +158,7 @@ def get_docstring(obj: Any, remove_newlines=True) -> str:
     if remove_newlines:
         stripped = [line.strip() for line in ds.splitlines() if line]
         return " ".join(stripped).replace("\n", " ").replace("\r", "")
-    return inspect.cleandoc(ds) # Strip spurious indentation/newlines
+    return inspect.cleandoc(ds)  # Strip spurious indentation/newlines
 
 
 def get_summary(obj: Any) -> str:

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -18,7 +18,6 @@ from ..schema import (
     build_action_schema,
 )
 from ..utilities import unpack
-from . import builder, op
 
 __all__ = ["MethodView", "View", "ActionView", "PropertyView", "op", "builder"]
 

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -173,7 +173,7 @@ class ActionView(View):
         """
         List running and completed actions.
 
-        Actions are run with `POST` requests.  See the `POST` method for this URL for 
+        Actions are run with `POST` requests.  See the `POST` method for this URL for
         details of the action.  Sending a `GET` request to an action endpoint will return
         action descriptions for each time the action has been run, including whether they
         have completed, and any return values.

--- a/src/labthings/views/__init__.py
+++ b/src/labthings/views/__init__.py
@@ -171,7 +171,12 @@ class ActionView(View):
     @classmethod
     def get(cls):
         """
-        Default method for GET requests. Returns the action queue (including already finished actions) for this action
+        List running and completed actions.
+
+        Actions are run with `POST` requests.  See the `POST` method for this URL for 
+        details of the action.  Sending a `GET` request to an action endpoint will return
+        action descriptions for each time the action has been run, including whether they
+        have completed, and any return values.
         """
         queue_schema = build_action_schema(cls.schema, cls.args)(many=True)
         return queue_schema.dump(cls._deque)

--- a/src/labthings/views/builder.py
+++ b/src/labthings/views/builder.py
@@ -4,10 +4,10 @@ import uuid
 from typing import Type
 
 from flask import abort, send_file
-from flask.views import MethodView
+from . import View
 
 
-def static_from(static_folder: str, name=None) -> Type[MethodView]:
+def static_from(static_folder: str, name=None) -> Type[View]:
     """
     :param static_folder: str:
     :param name:  (Default value = None)
@@ -37,6 +37,6 @@ def static_from(static_folder: str, name=None) -> Type[MethodView]:
             return send_file(indexes[0])
 
     # Generate a basic property class
-    generated_class = type(name, (MethodView, object), {"get": _get})
+    generated_class = type(name, (View, object), {"get": _get})
 
     return generated_class

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -30,6 +30,10 @@ def test_get_docstring(example_class):
         utilities.get_docstring(example_class)
         == "First line of class docstring. Second line of class docstring. "
     )
+    assert (
+        utilities.get_docstring(example_class, remove_newlines=False)
+        == "First line of class docstring.\nSecond line of class docstring."
+    )
 
     assert utilities.get_docstring(example_class.class_method) == (
         "First line of class method docstring. Second line of class method docstring. "


### PR DESCRIPTION
The OpenAPI docs currently leave quite a lot to be desired in the OpenFlexure Microscope.  In particular, using the same "description" for GET and POST methods on an Action is confusing, I think.  I've changed the APISpec plugin that extracts descriptions so that it looks on the get and post methods first for a docstring, then falls back to the class.

This enables me to make a much nicer API description. However, it might change descriptions in existing code, if there are docstrings on the methods that are currently being ignored.  I think this is likely a minor enough problem that it can be ignored...

I have also made what I think is quite a nice factory function to remove boilerplate code from ActionView definitions, I'm happy to add that here, or submit another PR.