### PR TITLE
Handle nullables

### DIFF
--- a/src/labthings/apispec/plugins.py
+++ b/src/labthings/apispec/plugins.py
@@ -112,11 +112,10 @@ class FlaskLabThingsPlugin(BasePlugin):
                 )
         return d
 
-    @classmethod
-    def spec_for_property(cls, prop):
-        class_schema = ensure_schema(prop.schema) or {}
+    def spec_for_property(self, prop):
+        class_schema = ensure_schema(self.spec, prop.schema) or {}
 
-        d = cls.spec_for_interaction(prop)
+        d = self.spec_for_interaction(prop)
 
         # Add in writeproperty methods
         for method in ("put", "post"):
@@ -155,9 +154,11 @@ class FlaskLabThingsPlugin(BasePlugin):
         return d
 
     def spec_for_action(self, action):
-        action_input = ensure_schema(action.args, name=f"{action.__name__}InputSchema")
+        action_input = ensure_schema(
+            self.spec, action.args, name=f"{action.__name__}InputSchema"
+        )
         action_output = ensure_schema(
-            action.schema, name=f"{action.__name__}OutputSchema"
+            self.spec, action.schema, name=f"{action.__name__}OutputSchema"
         )
         # We combine input/output parameters with ActionSchema using an
         # allOf directive, so we don't end up duplicating the schema

--- a/src/labthings/json/marshmallow_jsonschema/README
+++ b/src/labthings/json/marshmallow_jsonschema/README
@@ -3,4 +3,22 @@ This submodule is a modified version of fuhrysteve/marshmallow-jsonschema, with 
 This will convert any Marshmallow schema into a JSON schema, without any schema references or additional properties. 
 It will create a basic, inline schema only.
 
+It has also been modified (with the addition of `.base.convert_type_list_to_oneof`) to avoid returning list values for
+the type of a schema (this is valid JSON schema, but is not permitted in Thing Description syntax).  Instead, we expand
+the list, by creating a copy of the schema for each type, and combining them using `oneOf`.  This means that
+`fields.String(allow_none=True)`, which would previously be rendered as:
+```json
+{"type": ["string", "null"]}
+```
+will be dumped as
+```json
+{
+    "oneOf": [
+        {"type": "string"},
+        {"type": "null"}
+    ]
+}
+```
+This is also valid JSONSchema, though clearly less elegant.  However, it's required by the thing description.
+
 https://github.com/fuhrysteve/marshmallow-jsonschema

--- a/src/labthings/json/marshmallow_jsonschema/base.py
+++ b/src/labthings/json/marshmallow_jsonschema/base.py
@@ -79,6 +79,9 @@ def convert_type_list_to_oneof(schema):
     that use a list of types into a series of schemas each with
     one type.  Those schemas are then nested together using
     OneOf.
+
+    Schemas that do not have a type that is a list are returned
+    unmodified.
     """
     if "type" not in schema or type(schema["type"]) != list:
         return schema
@@ -223,8 +226,7 @@ class JSONSchema(Schema):
                 )
                 if base_class is not None and base_class in FIELD_VALIDATORS:
                     schema = FIELD_VALIDATORS[base_class](schema, field, validator, obj)
-        if "type" in schema and type(schema["type"]) == list:
-            schema = convert_type_list_to_oneof(schema)
+        schema = convert_type_list_to_oneof(schema)
         return schema
 
     def _from_nested_schema(self, _, field):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,17 @@ def thing_with_some_views(thing):
 
     thing.add_view(TestFieldProperty, "/TestFieldProperty")
 
+    class TestNullableFieldProperty(PropertyView):
+        schema = fields.Integer(allow_none=True)
+
+        def get(self):
+            return "one"
+
+        def post(self, args):
+            pass
+
+    thing.add_view(TestNullableFieldProperty, "/TestNullableFieldProperty")
+
     class FailAction(ActionView):
         wait_for = 0.1
 

--- a/tests/test_json_marshmallow_jsonschema.py
+++ b/tests/test_json_marshmallow_jsonschema.py
@@ -289,18 +289,23 @@ def test_readonly():
 
 
 def test_allow_none():
-    """A field with allow_none set to True should have type null as additional."""
+    """A field with allow_none set to True should be able to be null.
+
+    Note that this has been modified from JSONSchema behaviour: in
+    JSONSchema, "type" should be set to `["string", "null"]`.  This
+    is not allowed in Thing Descriptions, so instead we need to use
+    `oneOf`.  Our modified JSON schema library does this."""
 
     class TestSchema(Schema):
         id = fields.Integer(required=True)
-        readonly_fld = fields.String(allow_none=True)
+        nullable_fld = fields.String(allow_none=True)
 
     schema = TestSchema()
 
     dumped = validate_and_dump(schema)
 
-    assert dumped["properties"]["readonly_fld"] == {
-        "type": ["string", "null"],
+    assert dumped["properties"]["nullable_fld"] == {
+        "oneOf": [{"type": "string"}, {"type": "null"}],
     }
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -54,43 +54,49 @@ def test_duplicate_action_name(thing_with_some_views):
     assert original_input_schema != modified_input_schema
 
 
-def test_ensure_schema_field_instance():
-    ret = utilities.ensure_schema(fields.Integer())
+def test_ensure_schema_field_instance(spec):
+    ret = utilities.ensure_schema(spec, fields.Integer())
     assert ret == {"type": "integer"}
 
 
-def test_ensure_schema_field_class():
-    ret = utilities.ensure_schema(fields.Integer)
+def test_ensure_schema_nullable_field_instance(spec):
+    ret = utilities.ensure_schema(spec, fields.Integer(allow_none=True))
+    assert ret == {"type": "integer", "nullable": True}
+
+
+def test_ensure_schema_field_class(spec):
+    ret = utilities.ensure_schema(spec, fields.Integer)
     assert ret == {"type": "integer"}
 
 
-def test_ensure_schema_class():
-    ret = utilities.ensure_schema(LogRecordSchema)
+def test_ensure_schema_class(spec):
+    ret = utilities.ensure_schema(spec, LogRecordSchema)
     assert isinstance(ret, Schema)
 
 
-def test_ensure_schema_instance():
-    ret = utilities.ensure_schema(LogRecordSchema())
+def test_ensure_schema_instance(spec):
+    ret = utilities.ensure_schema(spec, LogRecordSchema())
     assert isinstance(ret, Schema)
 
 
-def test_ensure_schema_dict():
+def test_ensure_schema_dict(spec):
     ret = utilities.ensure_schema(
+        spec,
         {
             "count": fields.Integer(),
             "name": fields.String(),
-        }
+        },
     )
     assert isinstance(ret, Schema)
 
 
-def test_ensure_schema_none():
-    assert utilities.ensure_schema(None) is None
+def test_ensure_schema_none(spec):
+    assert utilities.ensure_schema(spec, None) is None
 
 
-def test_ensure_schema_error():
+def test_ensure_schema_error(spec):
     with pytest.raises(TypeError):
-        utilities.ensure_schema(Exception)
+        utilities.ensure_schema(spec, Exception)
 
 
 def test_get_marshmallow_plugin(spec):


### PR DESCRIPTION
W3C Thing Description does not permit the `type` of a `DataSchema` object to be a list.  This *is* valid JSON Schema, but *is not* valid Thing Description.  This most commonly occurs when fields are declared with `allow_none=True`.

This PR fixes two things:
* The updated OpenAPI conversion falls over, because converting nullable fields requires an initialised `APISpec` object and I was trying to fudge my way around it.
* The Thing Description is not valid, because it uses a customised `marshmallow_jsonschema` and doesn't enforce the Thing Description restriction on `type`.

I've fixed it in two places:
* A spec object is now passed to `labthings.openapi.utilities.ensure_schema` to make sure nullable fields are serialised correctly
* I've modified `marshmallow_jsonschema` so that it expands list types, as described in `labthings.json.marshmallow_jsonschema.base.convert_list_type_to_oneof`

This closes #267