### PR TITLE
Release locks on error

### DIFF
--- a/src/labthings/sync/lock.py
+++ b/src/labthings/sync/lock.py
@@ -53,9 +53,11 @@ class StrictLock:
     @contextmanager
     def __call__(self, timeout=sentinel, blocking: bool = True):
         result = self.acquire(timeout=timeout, blocking=blocking)
-        yield result
-        if result:
-            self.release()
+        try:
+            yield result
+        finally:
+            if result:
+                self.release()
 
     def locked(self):
         """ """
@@ -122,9 +124,11 @@ class CompositeLock:
     @contextmanager
     def __call__(self, timeout=sentinel, blocking: bool = True):
         result = self.acquire(timeout=timeout, blocking=blocking)
-        yield result
-        if result:
-            self.release()
+        try:
+            yield result
+        finally:
+            if result:
+                self.release()
 
     def acquire(self, blocking: bool = True, timeout=sentinel):
         """

--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -108,3 +108,13 @@ def test_rlock_acquire_timeout_fail(this_lock):
     with pytest.raises(lock.LockError):
         with this_lock(timeout=0.01):
             pass
+
+class DummyException(Exception):
+    pass
+
+def test_rlock_released_after_error(this_lock):
+    try:
+        with this_lock:
+            raise DummyException()
+    except DummyException:
+        assert not this_lock.locked()

--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -112,9 +112,29 @@ def test_rlock_acquire_timeout_fail(this_lock):
 class DummyException(Exception):
     pass
 
-def test_rlock_released_after_error(this_lock):
+def test_rlock_released_after_error_args(this_lock):
+    """If an exception occurs in a with block, the lock should release.
+    
+    NB there are two sets of code that do this - one if arguments are 
+    given (i.e. the __call__ method of the lock class) and one without
+    arguments (i.e. the __enter__ and __exit__ methods).
+
+    See the following function for the no-arguments version.
+    """
     try:
-        with this_lock:
+        with this_lock():
+            assert this_lock.locked()
             raise DummyException()
     except DummyException:
-        assert not this_lock.locked()
+        pass
+    assert not this_lock.locked()
+
+def test_rlock_released_after_error_noargs(this_lock):
+    """If an exception occurs in a with block, the lock should release."""
+    try:
+        with this_lock:
+            assert this_lock.locked()
+            raise DummyException()
+    except DummyException:
+        pass
+    assert not this_lock.locked()


### PR DESCRIPTION
There's a difference in behaviour between:
```
l = StrictLock()

with l:
    raise Exception
```
and
```
with l():
    raise Exception
```
The code that implements the latter (to allow arguments) does not release the lock if an error occurs.  This is now fixed, and a test is added to check both code paths.

Closes #274 